### PR TITLE
double promise

### DIFF
--- a/src/stubs/appMiddleware.ts
+++ b/src/stubs/appMiddleware.ts
@@ -13,6 +13,6 @@ export default class temp implements HttpMiddlewareInterface {
   }
 
   public responseError(error: AxiosError) {
-    return Promise.reject(error);
+    return error;
   }
 }


### PR DESCRIPTION
Hi, `responseError` returns one more promise, we cant use anymore error.response or other properties. 